### PR TITLE
Bump Ruby version on ci

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,9 @@ jobs:
     strategy:
       matrix:
         ruby:
-          - '3.1.2'
+          - '3.2.8'
+          - '3.3.8'
+          - '3.4.4'
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
# What

Close https://github.com/increments/json_schema_view/issues/2

- Bump Ruby version to current version

<!--
By contributing your code to this repository, you are deemed to agree to license your contribution under the Apache 2.0 license.
-->
