### PR TITLE
Fix github action version by hash

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,9 +19,9 @@ jobs:
           - '3.4.4'
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
     - name: Set up Ruby
-      uses: ruby/setup-ruby@v1
+      uses: ruby/setup-ruby@13e7a03dc3ac6c3798f4570bfead2aed4d96abfb # v1.244.0
       with:
         ruby-version: ${{ matrix.ruby }}
         bundler-cache: true


### PR DESCRIPTION
# What

Close https://github.com/increments/json_schema_view/issues/4

- Fix version of github actions by hash

# Refs

- https://docs.github.com/ja/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions

<!--
By contributing your code to this repository, you are deemed to agree to license your contribution under the repository license.
-->
